### PR TITLE
Add an option to use json file as credential source

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,9 +6,10 @@
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Ubuntu version: jammy / ubuntu-22.04, focal / ubuntu-20.04, bionic /ubuntu-18.04
 		// Use ubuntu-22.04 or ubuntu-18.04 on local arm64/Apple Silicon.
-		"args": { "VARIANT": "ubuntu-22.04" }
+		"args": {
+			"VARIANT": "ubuntu-22.04"
+		}
 	},
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	"extensions": [
@@ -19,14 +20,12 @@
 		"ms-python.python",
 		"streetsidesoftware.code-spell-checker"
 	],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "pip3 install --user -r requirements-test.txt",
-
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
 		"docker-from-docker": "latest",
-		"python": "3.9"
+		"python": "3.11"
 	}
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .secrets
 .env
 .vscode
+.idea
+.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.11-slim
 
 # install dependencies
 RUN  apt-get update \
@@ -65,7 +65,6 @@ RUN chmod +x /root/ib_account.py
 
 # set display environment variable (must be set after TWS installation)
 ENV DISPLAY=:0
-ENV GCP_SECRET=False
 
 ENV IBGW_PORT 4002
 ENV IBGW_WATCHDOG_CONNECT_TIMEOUT 30

--- a/README.md
+++ b/README.md
@@ -25,52 +25,79 @@ docker pull manhinhang/ib-gateway-docker
 ```
 
 ### Create a container from the image and run it
+
 ```bash
 docker run -d \
---env IB_ACCOUNT= \ #YOUR_USER_ID 
---env IB_PASSWORD= \ #YOUR_PASSWORD  
---env TRADE_MODE= \ #paper or live 
---p 4002:4002 \ #brige IB gateway port to your local port 4002
-manhinhang/ib-gateway-docker tail -f /dev/null
+  --env IB_ACCOUNT= \ # YOUR_USER_ID
+  --env IB_PASSWORD= \ # YOUR_PASSWORD
+  --env TRADE_MODE= \ # paper or live
+  --p 4002:4002 \ # bridge IB gateway port to your local port 4002
+  manhinhang/ib-gateway-docker tail -f /dev/null
 ```
 
 ---
 
-## Build & Run locally
+## Build & Run locally with Environment Variables
 
 ```bash
 git clone git@github.com:manhinhang/ib-gateway-docker.git
 cd ib-gateway-docker
 docker build --no-cache -t ib-gateway-docker .
+
 docker run -d \
---env IB_ACCOUNT= \ #YOUR_USER_ID 
---env IB_PASSWORD= \ #YOUR_PASSWORD  
---env TRADE_MODE= \ #paper or live 
--p 4002:4002 \ #brige IB gateway port to your local port 4002
-ib-gateway-docker \
-tail -f /dev/null
+  --env IB_ACCOUNT= \ # YOUR_USER_ID
+  --env IB_PASSWORD= \ # YOUR_PASSWORD
+  --env TRADE_MODE= \ # paper or live
+  -p 4002:4002 \ # bridge IB gateway port to your local port 4002
+  ib-gateway-docker \
+  tail -f /dev/null
 ```
 
+---
 
-## Container usage example
+### Run the container using File-based credentials
+
+#### Some secure credential providers for k8s expose an encrypted volume with a file-based mount. It is NOT recommended to use a simple volume mount containing the production keys
+
+#### The file should be JSON formatted containing the following
+
+```json
+{
+  "account": "<your account id>",
+  "password": "<your password>",
+  "trade_mode": "<Optional: can be set to live or paper>"
+}
+```
+
+#### When the trade_mode is not set in the JSON file, the value can be controlled with the TRADE_MODE environment variable
+
+#### Example (assuming credentials file is `./test.json`)
+
+```bash
+docker run -it \
+  --env IB_CREDENTIALS_FILEPATH="/mnt/test.json" \
+  -p 4002:4002 -v "./test.json:/mnt/test.json:Z" \
+  manhinhang/ib-gateway-docker tail -f /dev/null
+```
+
+### Container usage example
 
 | Example | Link | Description |
 | - | - | - |
 | ib_insync | [examples/ib_insync](./examples/ib_insync) | This example demonstrated how to connect `IB Gateway`
 | google cloud secret manager | [examples/google_cloud_secret_manager](./examples/google_cloud_secret_manager) | retreive your interactive brokers account from google cloud secret manager |
 
-
-# Tests
+## Tests
 
 The [test cases](test/test_ib_gateway.py) written with testinfra.
 
 Run the tests
 
-```
+```bash
 pytest
 ```
 
-# Github Actions for continuous integration
+## Github Actions for continuous integration
 
 After forking `IB Gateway docker` repository, you need config your **interactive brokers** paper account & password in *github secret*
 
@@ -79,7 +106,7 @@ After forking `IB Gateway docker` repository, you need config your **interactive
 | IB_ACCOUNT | your paper account name |
 | IB_PASSWORD | your paper account password |
 
-# Other environment variable
+## Other environment variable
 
 | Variable Name | Description | Default value |
 | - | - | - |
@@ -90,10 +117,8 @@ After forking `IB Gateway docker` repository, you need config your **interactive
 | IBGW_WATCHDOG_RETRY_DELAY | Ref to [ib_insync.ibcontroller.Watchdog.retryDelay](https://ib-insync.readthedocs.io/api.html#ib_insync.ibcontroller.Watchdog.retryDelay) | 2 |
 | IBGW_WATCHDOG_PROBE_TIMEOUT | Ref to [ib_insync.ibcontroller.Watchdog.probeTimeout](https://ib-insync.readthedocs.io/api.html#ib_insync.ibcontroller.Watchdog.probeTimeout) | 4 |
 
-
-# Disclaimer
+## Disclaimer
 
 This project is not affiliated with [Interactive Brokers Group, Inc.'s](https://www.interactivebrokers.com).
 
 Good luck and enjoy.
-

--- a/cmd.sh
+++ b/cmd.sh
@@ -3,23 +3,25 @@ set -e
 
 echo "Starting Xvfb..."
 rm -f /tmp/.X0-lock
-/usr/bin/Xvfb "$DISPLAY" -ac -screen 0 1024x768x16 +extension RANDR &
+/usr/bin/Xvfb "${DISPLAY}" -ac -screen 0 1024x768x16 +extension RANDR &
 
 echo "Waiting for Xvfb to be ready..."
-while ! xdpyinfo -display "$DISPLAY"; do
+while ! xdpyinfo -display "${DISPLAY}"; do
   echo -n ''
   sleep 0.1
 done
 
 echo "Xvfb is ready"
-echo "Setup port forwarding..."
+echo "Setup port forwarding on port: ${IBGW_PORT} using socat.."
 
-socat TCP-LISTEN:$IBGW_PORT,fork TCP:localhost:4001,forever &
+socat TCP-LISTEN:"${IBGW_PORT}",fork TCP:localhost:4001,forever &
 echo "*****************************"
+
+echo "Starting python bootstrap.."
 
 python /root/bootstrap.py
 
-echo "IB gateway is ready."
+echo "IB gateway is ready on port ${IBGW_PORT}"
 
 #Define cleanup procedure
 cleanup() {

--- a/examples/google_cloud_secret_manager/README.md
+++ b/examples/google_cloud_secret_manager/README.md
@@ -1,8 +1,8 @@
-# Example for google cloud secret manager
+# Example for Google cloud secret manager
 
-If you considing choose Google cloud as your IB gateway host, Google recommanded store your sensitive key in secret manager.
+If you're considering choose Google cloud as your IB gateway host, Google recommended store your sensitive key in secret manager.
 
-Reference: https://cloud.google.com/functions/docs/env-var#managing_secrets
+Reference: <https://cloud.google.com/functions/docs/env-var#managing_secrets>
 
 > Environment variables can be used for function configuration, but are not recommended as a way to store secrets such as database credentials or API keys. These more sensitive values should be stored outside both your source code and outside environment variables. Some execution environments or the use of some frameworks can result in the contents of environment variables being sent to logs, and storing sensitive credentials in YAML files, deployment scripts or under source control is not recommended.
 >
@@ -10,25 +10,25 @@ Reference: https://cloud.google.com/functions/docs/env-var#managing_secrets
 
 ---
 
-This example just shown you how run docker & retreive secret locally. 
+This example just shown you how run docker & retrieve secret locally.
 
 > *The deploy guide for google cloud may provide later.*
 
-1. Setup your credentials path
+1. Set up your credentials path
 
     ```bash
-    export GOOGLE_APPLICATION_CREDENTIALS= #your credentials json path
+    # your credentials json path
+    export GOOGLE_APPLICATION_CREDENTIALS=
     ```
 
 2. Run docker run command
 
     ```bash
     docker run --rm -it \
-    --env GCP_SECRET=True \ # Enable Google secret manager feature
     --env GCP_SECRET_IB_ACCOUNT= \ # secret key name of your interactive brokers account name
     --env GCP_SECRET_IB_PASSWORD= \ # secret key name of your interactive brokers password
     --env GCP_SECRET_IB_TRADE_MODE= \ # secret key name of trade mode
-    --env GCP_PROJECT_ID= \ #your project id
+    --env GCP_PROJECT_ID= \ # your project id
     -e GOOGLE_APPLICATION_CREDENTIALS=/tmp/keys/FILE_NAME.json \
     -v $GOOGLE_APPLICATION_CREDENTIALS:/tmp/keys/FILE_NAME.json:ro \
     manhinhang/ib-gateway-docker

--- a/examples/ib_insync/README.md
+++ b/examples/ib_insync/README.md
@@ -1,6 +1,6 @@
 # Example for starting up & connect IB Gateway
 
-This example showing how to using [ib_insync](https://github.com/erdewit/ib_insync) library to connect `IB Gateway` 
+This example showing how to use [ib_insync](https://github.com/erdewit/ib_insync) library to connect `IB Gateway`
 
 Python script
 
@@ -9,8 +9,9 @@ Python script
 | [connect_gateway.py](scripts/connect_gateway.py) | connect `IB Gateway` and retrieve historical data |
 
 ## Docker run command
+
 ```bash
-export TRADE_MODE=#paper or live
+export TRADE_MODE=# paper or live
 export IB_ACCOUNT=# your interactive brokers account name
 export IB_PASSWORD=# your interactive brokers account password
 

--- a/src/bootstrap.py
+++ b/src/bootstrap.py
@@ -1,7 +1,7 @@
 from ib_insync import IBC, IB, Watchdog
 import os
 import logging
-from ib_account import IBAccount
+import ib_account
 import sys
 
 if __name__ == "__main__":
@@ -9,49 +9,81 @@ if __name__ == "__main__":
     logging.info('start ib gateway...')
     logging.info('---ib gateway info---')
     twsPath = os.environ['twsPath']
-    logging.info('twsPath', twsPath)
+    logging.info(f'twsPath {twsPath}')
     gatewayRootPath = "{}/ibgateway".format(twsPath)
     ib_gateway_version = int(os.listdir(gatewayRootPath)[0])
     gatewayPath = "{}/{}".format(gatewayRootPath, ib_gateway_version)
     logging.info("ib gateway version:{}".format(ib_gateway_version))
     logging.info("ib gateway path:{}".format(gatewayPath))
     logging.info('-------------------')
-    account = IBAccount.account()
-    password = IBAccount.password()
-    trade_mode = IBAccount.trade_mode()
-    ibc = IBC(ib_gateway_version, 
-        gateway=True, 
-        tradingMode=trade_mode, 
-        userid=account, 
-        password=password, 
-        twsPath=twsPath)
+    ib_creds = ib_account.IBAccount()
+    if ib_account.IBAccount.isEnabledGCPSecret() and ib_account.IBAccount.isEnabledFileSecret():
+        # if both env vars are set, don't assume which is valid, and raise an exception
+        raise Exception('Both GCP and File provider enabled. Only 1 cred provider may be enabled.')
+    if ib_account.IBAccount.isEnabledGCPSecret():
+        logging.info("GCP Credential config detected.. Attempting to retrieve creds..")
+        ib_creds = ib_account.GCPIBAccount()
+    elif ib_account.IBAccount.isEnabledFileSecret():
+        logging.info("File Credentials config detected.. Attempting to retrieve creds..")
+        ib_creds = ib_account.FileCredsIBAccount()
+    else:
+        logging.info("No Credentials provider defined.. Attempting to retrieve creds from env vars..")
+        ib_creds = ib_account.IBAccount()
+    account = ib_creds.account()
+    password = ib_creds.password()
+    trade_mode = ib_creds.trade_mode()
+    ibc = IBC(ib_gateway_version,
+              gateway=True,
+              tradingMode=trade_mode,
+              userid=account,
+              password=password,
+              twsPath=twsPath)
     ib = IB()
+
+
     def onConnected():
         logging.info('IB gateway connected')
         logging.info(ib.accountValues())
-            
+
+
     def onDisconnected():
         logging.info('IB gateway disconnected')
+
+
     ib.connectedEvent += onConnected
     ib.disconnectedEvent += onDisconnected
-    watchdog = Watchdog(ibc, ib, port=4001, 
-        connectTimeout=int(os.environ['IBGW_WATCHDOG_CONNECT_TIMEOUT']), 
-        appStartupTime=int(os.environ['IBGW_WATCHDOG_APP_STARTUP_TIME']), 
-        appTimeout=int(os.environ['IBGW_WATCHDOG_APP_TIMEOUT']),
-        retryDelay=int(os.environ['IBGW_WATCHDOG_RETRY_DELAY']),
-        probeTimeout=int(os.environ['IBGW_WATCHDOG_PROBE_TIMEOUT']))
+    watchdog = Watchdog(ibc, ib, port=4001,
+                        connectTimeout=int(os.environ['IBGW_WATCHDOG_CONNECT_TIMEOUT']),
+                        appStartupTime=int(os.environ['IBGW_WATCHDOG_APP_STARTUP_TIME']),
+                        appTimeout=int(os.environ['IBGW_WATCHDOG_APP_TIMEOUT']),
+                        retryDelay=int(os.environ['IBGW_WATCHDOG_RETRY_DELAY']),
+                        probeTimeout=int(os.environ['IBGW_WATCHDOG_PROBE_TIMEOUT']))
+
+
     def onWatchDogStarting(_):
         logging.info('WatchDog Starting...')
+
+
     def onWatchDogStarted(_):
         logging.info('WatchDog Started!')
+
+
     def onWatchDogStopping(_):
         logging.info('WatchDog Stopping...')
+
+
     def onWatchDogStopped(_):
         logging.info('WatchDog Stopped!')
+
+
     def onWatchDogSoftTimeout(_):
         logging.info('WatchDog soft timeout!')
+
+
     def onWatchDogHardTimeoutEvent(_):
         logging.info('WatchDog hard timeout!')
+
+
     watchdog.startingEvent += onWatchDogStarting
     watchdog.startedEvent += onWatchDogStarted
     watchdog.stoppingEvent += onWatchDogStopping
@@ -61,4 +93,3 @@ if __name__ == "__main__":
     watchdog.start()
     ib.run()
     logging.info('IB gateway is ready.')
-    

--- a/src/ib_account.py
+++ b/src/ib_account.py
@@ -1,44 +1,111 @@
+import json
 import os
-from distutils.util import strtobool
-from google.cloud import secretmanager
+from abc import abstractmethod
+
 
 class IBAccount(object):
-    # Create the Secret Manager client.
-    __client = None
-   
-    @classmethod
-    def retrieve_secret(cls, secret_id):
-        if not cls.__client:
-            cls.__client = secretmanager.SecretManagerServiceClient()
-        gcp_project_id = os.environ['GCP_PROJECT_ID']
-        name = cls.__client.secret_version_path(gcp_project_id, secret_id, 'latest')
-        response = cls.__client.access_secret_version(name=name)
+
+    @abstractmethod
+    def __init__(self):
+        self.__client = None
+
+    @staticmethod
+    def isEnabledGCPSecret() -> bool:
+        try:
+            gcp_json_path = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', None)
+            if gcp_json_path is not None:
+                if os.path.exists(gcp_json_path):
+                    return True
+                else:
+                    raise FileNotFoundError(f'No GCP creds found at path: {gcp_json_path}')
+            return False
+        except ValueError:
+            return False
+
+    @staticmethod
+    def isEnabledFileSecret() -> bool:
+        try:
+            file_cred_path = os.environ.get('IB_CREDENTIALS_FILEPATH', None)
+            if file_cred_path is not None:
+                if os.path.exists(file_cred_path):
+                    return True
+                else:
+                    raise FileNotFoundError(f'No File creds found at path: {file_cred_path}')
+            return False
+        except ValueError:
+            return False
+
+    @abstractmethod
+    def account(self) -> str:
+        return os.environ['IB_ACCOUNT']
+
+    @abstractmethod
+    def password(self):
+        return os.environ['IB_PASSWORD']
+
+    @abstractmethod
+    def trade_mode(self):
+        return os.environ['TRADE_MODE']
+
+
+class FileCredsIBAccount(IBAccount):
+
+    def __init__(self):
+        super().__init__()
+        self.__file_path = os.environ.get('IB_CREDENTIALS_FILEPATH', None)
+        if self.__file_path is None:
+            raise ValueError("IB_CREDENTIALS_FILEPATH Env var not set!")
+        try:
+            self.__creds = json.load(open(self.__file_path))
+        except FileNotFoundError as e:
+            raise FileNotFoundError(f'No file at {self.__file_path}')
+        except Exception as e:
+            raise e
+
+    def password(self) -> str:
+        try:
+            return self.__creds['password']
+        except ValueError:
+            raise ValueError(f'key "password" not found in JSON file: {self.__file_path}')
+
+    def account(self) -> str:
+        try:
+            return self.__creds['account']
+        except ValueError:
+            raise ValueError(f'key "account" not found in JSON file: {self.__file_path}')
+
+    def trade_mode(self) -> str:
+        if 'trade_mode' in self.__creds:
+            return self.__creds['trade_mode']
+        else:
+            trade_mode = os.environ.get('TRADE_MODE', None)
+            if trade_mode is not None:
+                return trade_mode
+        raise ValueError(f'trade_mode not set in {self.__file_path} and TRADE_MODE not set as env var!')
+
+
+class GCPIBAccount(IBAccount):
+    def __init__(self):
+        super().__init__()
+        from google.cloud import secretmanager
+        gcp_creds_path = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', None)
+        if gcp_creds_path:
+            self.__gcp_project_id = os.environ['GCP_PROJECT_ID']
+            self.__client = secretmanager.SecretManagerServiceClient.from_service_account_json(gcp_creds_path)
+        else:
+            raise ValueError('Need to set env var for GOOGLE_APPLICATION_CREDENTIALS to use GCP credentials!')
+
+    def retrieve_gcp_secret(self, secret_id):
+        name = self.__client.secret_version_path(self.__gcp_project_id, secret_id, 'latest')
+        response = self.__client.access_secret_version(name=name)
         payload = response.payload.data.decode('UTF-8')
         return payload
 
-    @staticmethod
-    def isEnabledGCPSecret():
-        try:
-            return bool(strtobool(os.environ['GCP_SECRET']))
-        except ValueError:
-            return False
-    
-    @classmethod
-    def account(cls):
-        if not cls.isEnabledGCPSecret():
-            return os.environ['IB_ACCOUNT']
-        return cls.retrieve_secret(os.environ['GCP_SECRET_IB_ACCOUNT'])
-    
-    @classmethod
-    def password(cls):
-        if not cls.isEnabledGCPSecret():
-            return os.environ['IB_PASSWORD']
-        return cls.retrieve_secret(os.environ['GCP_SECRET_IB_PASSWORD'])
+    def account(self) -> str:
+        return self.retrieve_gcp_secret(os.environ['GCP_SECRET_IB_ACCOUNT'])
 
-    @classmethod
-    def trade_mode(cls):
-        if not cls.isEnabledGCPSecret():
-            return os.environ['TRADE_MODE']
-        return cls.retrieve_secret(os.environ['GCP_SECRET_IB_TRADE_MODE'])
+    def password(self):
+        return self.retrieve_gcp_secret(os.environ['GCP_SECRET_IB_PASSWORD'])
 
-    
+    def trade_mode(self):
+        return self.retrieve_gcp_secret(os.environ['GCP_SECRET_IB_TRADE_MODE'])

--- a/test/test_docker_interactive.py
+++ b/test/test_docker_interactive.py
@@ -1,11 +1,10 @@
 import pytest
 import os
 import subprocess
-import time
 from ib_insync import IB, util, Forex
-import asyncio
 
 IMAGE_NAME = os.environ['IMAGE_NAME']
+
 
 @pytest.fixture(scope='function')
 def ib_docker():
@@ -15,13 +14,13 @@ def ib_docker():
 
     # run a container
     docker_id = subprocess.check_output(
-        ['docker', 'run', 
-        '--env', 'IB_ACCOUNT={}'.format(account),
-        '--env', 'IB_PASSWORD={}'.format(password),
-        '--env', 'TRADE_MODE={}'.format(trade_mode),
-        '-p', '4002:4002',
-        '-d', IMAGE_NAME, 
-        "tail", "-f", "/dev/null"]).decode().strip()
+        ['docker', 'run',
+         '--env', 'IB_ACCOUNT={}'.format(account),
+         '--env', 'IB_PASSWORD={}'.format(password),
+         '--env', 'TRADE_MODE={}'.format(trade_mode),
+         '-p', '4002:4002',
+         '-d', IMAGE_NAME,
+         "tail", "-f", "/dev/null"]).decode().strip()
     yield docker_id
     subprocess.check_call(['docker', 'rm', '-f', docker_id])
 
@@ -38,7 +37,7 @@ def test_ibgw_interactive(ib_docker):
         wait -= 1
         if wait <= 0:
             break
-    
+
     contract = Forex('EURUSD')
     bars = ib.reqHistoricalData(
         contract, endDateTime='', durationStr='30 D',
@@ -47,14 +46,14 @@ def test_ibgw_interactive(ib_docker):
     # convert to pandas dataframe:
     df = util.df(bars)
     print(df)
-    
-def test_ibgw_restart(ib_docker):
 
+
+def test_ibgw_restart(ib_docker):
     subprocess.check_output(
         ['docker', 'container', 'stop', ib_docker]).decode().strip()
     subprocess.check_output(
         ['docker', 'container', 'start', ib_docker]).decode().strip()
-    
+
     ib = IB()
     wait = 60
     while not ib.isConnected():
@@ -66,7 +65,7 @@ def test_ibgw_restart(ib_docker):
         wait -= 1
         if wait <= 0:
             break
-    
+
     contract = Forex('EURUSD')
     bars = ib.reqHistoricalData(
         contract, endDateTime='', durationStr='30 D',

--- a/test/test_ib_gateway.py
+++ b/test/test_ib_gateway.py
@@ -5,6 +5,7 @@ import os
 
 IMAGE_NAME = os.environ['IMAGE_NAME']
 
+
 # scope='session' uses the same container for all the tests;
 # scope='function' uses a new container per test function.
 @pytest.fixture(scope='session')
@@ -15,19 +16,21 @@ def host(request):
 
     # run a container
     docker_id = subprocess.check_output(
-        ['docker', 'run', 
-        '--env', 'IB_ACCOUNT={}'.format(account),
-        '--env', 'IB_PASSWORD={}'.format(password),
-        '--env', 'TRADE_MODE={}'.format(trade_mode),
-        '-d', IMAGE_NAME, 
-        "tail", "-f", "/dev/null"]).decode().strip()
+        ['docker', 'run',
+         '--env', 'IB_ACCOUNT={}'.format(account),
+         '--env', 'IB_PASSWORD={}'.format(password),
+         '--env', 'TRADE_MODE={}'.format(trade_mode),
+         '-d', IMAGE_NAME,
+         "tail", "-f", "/dev/null"]).decode().strip()
     # return a testinfra connection to the container
     yield testinfra.get_host("docker://" + docker_id)
     # at the end of the test suite, destroy the container
     subprocess.check_call(['docker', 'rm', '-f', docker_id])
 
+
 def test_ibgateway_version(host):
     int(host.run("ls /root/Jts/ibgateway").stdout)
+
 
 def test_ib_connect(host):
     script = """

--- a/test/test_ib_gateway_fail.py
+++ b/test/test_ib_gateway_fail.py
@@ -2,9 +2,9 @@ import pytest
 import subprocess
 import testinfra
 import os
-import time
 
 IMAGE_NAME = os.environ['IMAGE_NAME']
+
 
 # scope='session' uses the same container for all the tests;
 # scope='function' uses a new container per test function.
@@ -16,16 +16,17 @@ def host(request):
 
     # run a container
     docker_id = subprocess.check_output(
-        ['docker', 'run', 
-        '--env', 'IB_ACCOUNT={}'.format(account),
-        '--env', 'IB_PASSWORD={}'.format(password),
-        '--env', 'TRADE_MODE={}'.format(trade_mode),
-        '-d', IMAGE_NAME, 
-        "tail", "-f", "/dev/null"]).decode().strip()
+        ['docker', 'run',
+         '--env', 'IB_ACCOUNT={}'.format(account),
+         '--env', 'IB_PASSWORD={}'.format(password),
+         '--env', 'TRADE_MODE={}'.format(trade_mode),
+         '-d', IMAGE_NAME,
+         "tail", "-f", "/dev/null"]).decode().strip()
     # return a testinfra connection to the container
     yield testinfra.get_host("docker://" + docker_id)
     # at the end of the test suite, destroy the container
     subprocess.check_call(['docker', 'rm', '-f', docker_id])
+
 
 def test_ib_connect_fail(host):
     script = """


### PR DESCRIPTION
A number of k8s secrets providers will expose an encrypted volume mount with a file path with which to provide secrets. This allows a file path to be defined as IB_CREDENTIALS_FILEPATH with a JSON dict containing "account" "password" and "trade_mode" as keys for their respective params.

I also eliminated the GCP_SECRET env var usage since it seemed redundant when GOOGLE_APPLICATION_CREDENTIALS is defined.

I had trouble running the tests locally, as I am using podman and the docker socket did not seem to have the right permissions.

I do not have access to a GCP setup so help testing for regressions would be appreciated