### PR TITLE
Review fixes — PR D: Node 24 opt-in + JSON parser hardening

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,5 +1,5 @@
 name: Build test
-on: 
+on:
   push:
     branches:
       - develop
@@ -8,6 +8,12 @@ on:
       - 'README.md'
       - 'LICENSE'
   pull_request:
+
+env:
+  # Opt every JavaScript-based action into Node.js 24. Node 20 is deprecated
+  # on GitHub-hosted runners and will be removed on 2026-09-16; without this
+  # the next runner upgrade silently fails any action still on Node 20.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,11 @@ on:
        - '*'
    workflow_dispatch:
 
+env:
+  # Opt JS-based actions into Node 24; Node 20 is deprecated and will be
+  # removed from runners on 2026-09-16.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/detect-new-ver.yml
+++ b/.github/workflows/detect-new-ver.yml
@@ -3,6 +3,12 @@ on:
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
+
+env:
+  # Opt JS-based actions into Node 24; Node 20 is deprecated and will be
+  # removed from runners on 2026-09-16.
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/detect-new-ver.yml
+++ b/.github/workflows/detect-new-ver.yml
@@ -23,10 +23,10 @@ jobs:
     - name: detect new versions
       id: check-update
       run: |
-        IB_GATEWAY_LATEST_VER=$(curl -fsSL "https://download2.interactivebrokers.com/installers/ibgateway/latest-standalone/version.json" | \
-        grep -Po '"buildVersion"\s*:\s*"\K[^"]+')
-        IB_GATEWAY_STABLE_VER=$(curl -fsSL "https://download2.interactivebrokers.com/installers/ibgateway/stable-standalone/version.json" | \
-        grep -Po '"buildVersion"\s*:\s*"\K[^"]+')
+        # version.json is JSONP (callback-wrapped); strip the wrapper, then jq.
+        strip_jsonp() { sed -E 's/^[^(]+\(//; s/\);[[:space:]]*$//'; }
+        IB_GATEWAY_LATEST_VER=$(curl -fsSL "https://download2.interactivebrokers.com/installers/ibgateway/latest-standalone/version.json" | strip_jsonp | jq -r '.buildVersion')
+        IB_GATEWAY_STABLE_VER=$(curl -fsSL "https://download2.interactivebrokers.com/installers/ibgateway/stable-standalone/version.json" | strip_jsonp | jq -r '.buildVersion')
         IBC_VER=$(curl -fsSL "${IBC_VERSION_JSON_URL}" | jq -r '.[0].name')
         source .env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,12 @@ RUN IBC_ASSET_URL=$(curl -fsSL ${IBC_VERSION_JSON_URL} | jq -r '.[0].assets[]|se
 # copy IBC/Jts configs
 COPY ibc/config.ini ${IBC_INI}
 
-# Extract IB Gateway version
+# Extract IB Gateway version. version.json is JSONP (callback-wrapped),
+# e.g. `ibgatewaylatest_callback({"buildVersion":"10.46.1d",...});`.
+# Strip the callback wrapper before piping to jq.
 RUN curl -fsSL "https://download2.interactivebrokers.com/installers/ibgateway/${CHANNEL}-standalone/version.json" \
- | grep -Po '"buildVersion"\s*:\s*"\K[^"]+' \
- | head -1 > /tmp/ibgw-version
+ | sed -E 's/^[^(]+\(//; s/\);[[:space:]]*$//' \
+ | jq -r '.buildVersion' > /tmp/ibgw-version
 
 ######## healthcheck tools ########
 # temp container to build using gradle


### PR DESCRIPTION
## Summary

Stop-gap PR for the two outstanding review items that don't need a product decision. The other four (M9 supply-chain, M12 WebFlux, M15 2FA device, M16 session preempt) stay deferred — left for a follow-up once you weigh in.

| Item | Severity | Subject | Commit |
|---|---|---|---|
| Node 20 deprecation | (CI EOL) | Set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` at workflow `env:` level in all 3 workflows so JS-based actions run on Node 24 today | `2cfd293` |
| M11 | MED | Replace `grep -Po '"buildVersion"...'` with sed-strip-JSONP + `jq -r .buildVersion` in Dockerfile and detect-new-ver.yml | `4bbcbf3` |

## Why M11 needed JSONP investigation

I curl'd the actual `version.json`:

```
ibgatewaylatest_callback({"buildVersion":"10.46.1d","buildDateTime":"20260429 16:01:19"});
```

It's JSONP — a callback name + parens + trailing semicolon. Plain `jq` chokes on that. The `sed -E 's/^[^(]+\(//; s/\);[[:space:]]*$//'` strips the wrapper; `jq -r .buildVersion` then yields the version string. Fails loudly on schema change instead of silently mis-parsing.

## Test plan

- [x] CI `Build Docker image` succeeds (the new sed+jq pipeline runs in the downloader stage)
- [x] `Verify healthcheck inside container` is unchanged (this fix does not touch runtime)
- [ ] CI annotations no longer flag Node 20 deprecation

## Risks

- **The sed regex is permissive** — strips anything up to and including the first `(`, then anything after the last `)`. If IB ever returns a redirect HTML page, jq will fail on the body. That's the intended fail-loud behavior.
- **`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`** is a documented stop-gap. Once `actions/setup-python`, `docker/build-push-action`, and `actions/checkout` ship Node-24 builds and we bump their tags, the env var can be removed.

## Outstanding after this lands

| Item | Severity | Status |
|---|---|---|
| M9 — SHA256-pin installers | MED | Awaiting input — real feature, larger effort |
| M12 — `runBlocking` → WebFlux | MED | Awaiting input — cosmetic at current traffic |
| M15 — `SecondFactorDevice` default | MED | Awaiting input — depends on user's 2FA method |
| M16 — `ExistingSessionDetectedAction=primary` | MED | Awaiting input — keep aggressive or change to `manual`? |