### PR TITLE
feat: add Kubernetes example and k3d-based CI verification

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
-    timeout-minutes: 20
+    timeout-minutes: 25
     env:
       IMAGE_NAME: ib-gateway-docker
     steps:
@@ -89,6 +89,72 @@ jobs:
         IB_ACCOUNT: ${{ secrets.IB_ACCOUNT }}
         IB_PASSWORD: ${{ secrets.IB_PASSWORD }}
         TRADING_MODE: paper
+
+    # ── k8s: stand up a k3d cluster, deploy examples/k8s/single.yaml,
+    # and confirm the pod reaches Ready (which transitively confirms the
+    # /healthcheck/bin/healthcheck probe passes — same contract as the
+    # docker-exec healthcheck step above, but exercising the StatefulSet,
+    # Secret, PVC, and seed-jts initContainer wiring).
+    - name: Set up k3d
+      run: |
+        # Pinned to the v5.7.5 install.sh by commit SHA — protects against
+        # main-branch compromise of the script even though TAG is also
+        # pinned below. -f makes curl fail on HTTP errors instead of piping
+        # an empty body to bash; -L follows the GitHub raw redirect.
+        curl -fsSL \
+          "https://raw.githubusercontent.com/k3d-io/k3d/b1c64bcb459e266b92ff1d0820a62a6541b1efb5/install.sh" \
+          | TAG=v5.7.5 bash
+        k3d version
+        kubectl version --client
+
+    - name: Create k3d cluster
+      run: |
+        k3d cluster create ib-gateway-ci \
+          --no-lb --servers 1 --agents 0 --wait
+
+    - name: Import image into k3d
+      run: k3d image import "$IMAGE_NAME" -c ib-gateway-ci
+
+    - name: Apply manifests with real credentials
+      run: |
+        # Swap the image tag in the manifest to the locally-built CI image.
+        sed -E "s|image: manhinhang/ib-gateway-docker:latest|image: ${IMAGE_NAME}|g" \
+          examples/k8s/single.yaml \
+          | kubectl apply -f -
+        # Replace the REPLACE_ME Secret with real paper credentials.
+        kubectl -n ib-gateway create secret generic ib-gateway \
+          --from-literal=IB_ACCOUNT="$IB_ACCOUNT" \
+          --from-literal=IB_PASSWORD="$IB_PASSWORD" \
+          --dry-run=client -o yaml | kubectl apply -f -
+        # Pick up the new Secret values.
+        kubectl -n ib-gateway rollout restart statefulset/ib-gateway
+      env:
+        IB_ACCOUNT: ${{ secrets.IB_ACCOUNT }}
+        IB_PASSWORD: ${{ secrets.IB_PASSWORD }}
+
+    - name: Wait for rollout to complete
+      run: |
+        # rollout status is race-tolerant across rollout-restart pod
+        # recreation (kubectl wait pod/<name> can exit with "no matching
+        # resources found" during the brief window where the pod is
+        # deleted and not yet recreated). It also requires every replica
+        # to satisfy the readiness probe — same /healthcheck/bin/healthcheck
+        # binary the docker test uses — so it doubles as the healthcheck
+        # gate for the k8s wiring. 5 min covers 60s probe initial delay +
+        # 60s period + ~30-60s IB Gateway login + runner CPU jitter.
+        kubectl -n ib-gateway rollout status statefulset/ib-gateway --timeout=300s
+
+    - name: Dump k8s diagnostics on failure
+      if: failure()
+      run: |
+        kubectl -n ib-gateway get all -o wide || true
+        kubectl -n ib-gateway describe pod ib-gateway-0 || true
+        kubectl -n ib-gateway logs ib-gateway-0 -c seed-jts --tail=50 || true
+        kubectl -n ib-gateway logs ib-gateway-0 --tail=200 || true
+
+    - name: Tear down k3d cluster
+      if: always()
+      run: k3d cluster delete ib-gateway-ci || true
 
     - name: Stop and remove leftover containers
       if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,17 @@ docker compose -f docker-compose.multi.yaml up -d
 # paper → localhost:4002, live → localhost:4001
 ```
 
+### Running on Kubernetes
+
+Plain-YAML manifests for both single and multi-gateway are in
+[`examples/k8s/`](examples/k8s/), with a k3d-based local verification
+helper at [`scripts/k8s/k3d-up.sh`](scripts/k8s/k3d-up.sh). The compose
+multi setup's per-service `IBGW_INTERNAL_PORT` and
+`IBC_COMMAND_SERVER_PORT` overrides do **not** transfer — those exist
+only because `network_mode: host` makes paper and live share the host's
+loopback. Each k8s pod has its own network namespace, so both pods keep
+upstream defaults inside themselves and only `IBGW_PORT` differs.
+
 ### Running Tests
 
 Tests use **pytest** and **testinfra**:

--- a/examples/k8s/README.md
+++ b/examples/k8s/README.md
@@ -1,0 +1,217 @@
+# IB Gateway on Kubernetes
+
+Plain-YAML Kubernetes manifests that mirror this repo's two compose
+entrypoints, plus a k3d-based local verification path.
+
+| Manifest | Mirrors | What it deploys |
+|---|---|---|
+| [`single.yaml`](single.yaml) | `docker-compose.yaml` | one IB Gateway StatefulSet, one Service, one Secret, namespace `ib-gateway` |
+| [`multi.yaml`](multi.yaml) | `docker-compose.multi.yaml` | paper + live StatefulSets/Services/Secrets, namespace `ib-gateway` |
+
+## Why StatefulSet
+
+`/root/Jts` holds the IBKR device fingerprint (and the daily autorestart
+file) for one specific account. A pod must keep its PVC for life — a
+fresh PVC means re-doing 2FA. StatefulSet's `volumeClaimTemplates` is
+the natural fit; `replicas: 1` per gateway. See [CLAUDE.md → Session
+Persistence](../../CLAUDE.md) for the underlying mechanics.
+
+## Why the initContainer
+
+The image bakes the IB Gateway binary into `/root/Jts/ibgateway/<version>/`.
+Docker auto-seeds named volumes from the image on first mount, so the
+binary "appears" inside the docker volume. **Kubernetes PVCs always
+start empty**, so without intervention the mount would hide the image's
+binary and `start.sh` would fail with `ls: cannot access
+/root/Jts/ibgateway: No such file or directory`.
+
+Each StatefulSet has a `seed-jts` initContainer that runs once per
+pod start and `cp -rn`s the image's `/root/Jts/*` onto the PVC — first
+start fills it from scratch, subsequent starts only fill gaps. This
+matches docker's "auto-populate from image" semantics and preserves
+the runtime state (`jts.ini`, device fingerprint, autorestart file)
+that gets added later. Same caveat as docker — wipe the PVC after a
+version bump in `versions.env`, otherwise the stale binary stays put.
+
+## What's intentionally simpler than compose
+
+`docker-compose.multi.yaml` uses `network_mode: host` and so has to give
+paper and live distinct `IBGW_INTERNAL_PORT` (4011 / 4012) and
+`IBC_COMMAND_SERVER_PORT` (7462 / 7463) values to keep their loopback
+ports from colliding. Each k8s pod has its own network namespace, so
+**none of that applies** — both pods can keep the upstream defaults
+(`IBGW_INTERNAL_PORT=4001`, `IBC_COMMAND_SERVER_PORT=7462`) inside
+themselves. The only thing paper and live differ on at the manifest
+level is the externally-visible `IBGW_PORT` (4002 / 4001), so that
+`localhost:4002` (paper) / `localhost:4001` (live) still works from
+the host via `kubectl port-forward`.
+
+## What's the same as compose
+
+- `IB_ACCOUNT` / `IB_PASSWORD` come from a Secret (mounted as env). The
+  manifest ships the Secret with `REPLACE_ME` placeholders — replace
+  before the gateway can log in.
+- The Java `/healthcheck/bin/healthcheck` binary is the liveness +
+  readiness probe; same 60s/30s/3-retry/60s-grace timing as compose.
+- IBC's command server is bound to `127.0.0.1` inside each pod and is
+  **not exposed** as a Service. Loopback-only is the same trust
+  boundary the docker setup enforces; reach it via `kubectl exec`.
+
+## Quickstart on k3d
+
+The `scripts/k8s/k3d-up.sh` helper does everything: create cluster,
+build local image, import into the cluster, apply manifest, run a
+smoke check.
+
+```bash
+# Default: single gateway, smoke-only (Secret stays at REPLACE_ME).
+./scripts/k8s/k3d-up.sh
+
+# Multi-gateway:
+MANIFEST=examples/k8s/multi.yaml ./scripts/k8s/k3d-up.sh
+
+# With real paper credentials — pod will go all the way to Ready:
+IB_ACCOUNT=… IB_PASSWORD=… ./scripts/k8s/k3d-up.sh
+```
+
+Reach the gateway from your workstation:
+
+```bash
+kubectl -n ib-gateway port-forward svc/ib-gateway 4002:4002
+# Then your IB API client connects to localhost:4002 as usual.
+```
+
+Tear down:
+
+```bash
+./scripts/k8s/k3d-down.sh
+```
+
+## Smoke vs full verification
+
+`k3d-up.sh` is a **smoke** test by default. Pass criteria:
+
+- PVC is `Bound`
+- Pod reaches `Running` (image pulls, container starts)
+- `start.sh` runs Xvfb, IBC begins the login attempt
+- Required env vars are wired into the container (`IBGW_PORT`,
+  `TRADING_MODE`, `IB_ACCOUNT` set)
+
+Without real IBKR credentials the pod stays in `Running` but never
+reaches `Ready` — IBC can't log in, so the `/healthcheck/bin/healthcheck`
+probe keeps failing. That's the right stopping point for "is the k8s
+wiring correct?".
+
+For the **full** verification — same contract as the existing
+[`scripts/verify-session-persistence.sh`](../../scripts/verify-session-persistence.sh):
+
+```bash
+# 1. Put real paper credentials into the Secret (or pass them to k3d-up.sh).
+kubectl -n ib-gateway create secret generic ib-gateway \
+    --from-literal=IB_ACCOUNT="$IB_ACCOUNT" \
+    --from-literal=IB_PASSWORD="$IB_PASSWORD" \
+    --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n ib-gateway rollout restart statefulset/ib-gateway
+
+# 2. Complete 2FA on the IBKR mobile app on this first start.
+kubectl -n ib-gateway wait --for=condition=ready pod/ib-gateway-0 --timeout=300s
+
+# 3. Run the k8s-native session-persistence check.
+./scripts/k8s/verify-session-persistence-k8s.sh
+```
+
+## Soft restart from the host
+
+`scripts/k8s/restart-ib-gateway-k8s.sh` is the k8s analogue of
+`scripts/restart-ib-gateway.sh`. It `kubectl exec`s into the pod and
+sends `RESTART\n` to IBC's command server on `127.0.0.1:7462` — the
+**same** loopback path the docker script uses, just reached via
+`kubectl exec` instead of bash redirection on the host. This preserves
+the loopback-only trust boundary; nothing in the cluster network can
+reach the command server.
+
+```bash
+# Defaults: namespace=ib-gateway, label app=ib-gateway, port=7462
+./scripts/k8s/restart-ib-gateway-k8s.sh
+
+# Multi: target a specific pod
+POD=ib-gateway-paper-0 ./scripts/k8s/restart-ib-gateway-k8s.sh
+POD=ib-gateway-live-0  ./scripts/k8s/restart-ib-gateway-k8s.sh
+```
+
+## If k3d can't reach Docker Hub
+
+Some hosts have flaky outbound DNS on docker's default bridge network
+(the same issue `docker-compose.yaml` documents with `network: host`
+on builds). Symptom: k3s system pods stuck in `ErrImagePull` /
+`ImagePullBackOff` with `TLS handshake timeout` to `auth.docker.io` or
+`registry-1.docker.io`. Two fixes:
+
+### Preferred: host networking
+
+Run k3d on the host network so the k3s server container shares the
+host's `/etc/resolv.conf`. If `docker pull` works on the host, this
+makes containerd inside k3s work too:
+
+```bash
+USE_HOST_NETWORK=1 ./scripts/k8s/k3d-up.sh
+```
+
+Caveat: k3d's prep step inspects every container on the host network,
+and bails with `ParseAddr("")` if any of them have no IP set
+(common with long-running runners like `act`). If the cluster fails to
+create with that error, list the offenders with
+`docker network inspect host --format '{{json .Containers}}'` and
+either stop them or use the fallback below.
+
+### Fallback: pre-pull and ctr-import
+
+When host networking isn't available, pre-pull the k3s system images
+on the host and import them via `ctr`:
+
+```bash
+for img in rancher/mirrored-pause:3.6 \
+           rancher/local-path-provisioner:v0.0.30 \
+           rancher/mirrored-coredns-coredns:1.11.3 \
+           rancher/mirrored-metrics-server:v0.7.2 \
+           rancher/klipper-helm:v0.9.3-build20241008 \
+           rancher/mirrored-library-busybox:1.36.1 \
+           rancher/mirrored-library-traefik:2.11.10 \
+           rancher/klipper-lb:v0.4.9; do
+    docker pull "$img"
+done
+docker save rancher/mirrored-pause:3.6 \
+            rancher/local-path-provisioner:v0.0.30 \
+            rancher/mirrored-coredns-coredns:1.11.3 \
+            rancher/mirrored-metrics-server:v0.7.2 \
+            rancher/klipper-helm:v0.9.3-build20241008 \
+            rancher/mirrored-library-busybox:1.36.1 \
+            rancher/mirrored-library-traefik:2.11.10 \
+            rancher/klipper-lb:v0.4.9 \
+    -o /tmp/k3s.tar
+docker cp /tmp/k3s.tar k3d-ib-gateway-server-0:/tmp/k3s.tar
+docker exec k3d-ib-gateway-server-0 ctr -n=k8s.io image import /tmp/k3s.tar
+```
+
+The exact tags depend on the k3d / k3s versions in use — check
+`kubectl -n kube-system get pods -o jsonpath='{range .items[*]}{.spec.containers[*].image}{"\n"}{end}'`
+on a fresh cluster to see what your version pulls. `k3d image import`
+itself is unreliable for the kube-system images on some k3d versions
+(imports land in the wrong containerd namespace); going through `ctr`
+directly avoids that. The application image
+(`manhinhang/ib-gateway-docker:dev`) that `k3d-up.sh` imports works
+fine via `k3d image import`.
+
+## Production notes (NOT covered by k3d)
+
+What this example deliberately does **not** do, because it would either
+not work the same on k3d or would distract from the core mapping:
+
+- **NetworkPolicy** locking inbound to `IBGW_PORT` only — recommended
+  for shared clusters.
+- **PodDisruptionBudget** — for clusters where node maintenance could
+  evict the pod during a trading window.
+- **External DNS / Ingress** for the API port — most setups expose the
+  gateway only to other in-cluster workloads via the ClusterIP.
+- **Backups** of the `jts` PVC — losing it means re-doing 2FA on the
+  next start, exactly as in the docker setup.

--- a/examples/k8s/multi.yaml
+++ b/examples/k8s/multi.yaml
@@ -1,0 +1,337 @@
+# Paper + live IB Gateways on Kubernetes, side-by-side.
+#
+# Mirrors docker-compose.multi.yaml but **without** the Docker-only port
+# juggling:
+#
+#   docker-compose.multi.yaml uses network_mode: host, so paper and live
+#   share the host's loopback. To stop their IB Gateway and IBC command
+#   server processes from racing for the same TCP port, the compose file
+#   gives them distinct IBGW_INTERNAL_PORT (4011 / 4012) and
+#   IBC_COMMAND_SERVER_PORT (7462 / 7463) values.
+#
+#   In k8s, each pod has its own network namespace, so the two pods are
+#   completely isolated on loopback. We can leave IBGW_INTERNAL_PORT at
+#   the upstream default 4001 and IBC_COMMAND_SERVER_PORT at 7462 inside
+#   *both* pods — no collision possible. The only thing that has to
+#   differ between paper and live is IBGW_PORT (4002 / 4001), so the
+#   familiar `localhost:4002` (paper) / `localhost:4001` (live) works
+#   from the host via port-forward.
+#
+# Apply:
+#
+#   kubectl apply -f examples/k8s/multi.yaml
+#
+#   # paper-only smoke (skip live):
+#   kubectl apply -f examples/k8s/multi.yaml \
+#     -l 'mode in (shared,paper)'
+#
+# Set credentials BEFORE the pods need them:
+#
+#   kubectl -n ib-gateway create secret generic ib-gateway-paper \
+#     --from-literal=IB_ACCOUNT="$IB_PAPER_ACCOUNT" \
+#     --from-literal=IB_PASSWORD="$IB_PAPER_PASSWORD" \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#
+#   kubectl -n ib-gateway create secret generic ib-gateway-live \
+#     --from-literal=IB_ACCOUNT="$IB_LIVE_ACCOUNT" \
+#     --from-literal=IB_PASSWORD="$IB_LIVE_PASSWORD" \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#
+# Connect from your workstation:
+#
+#   kubectl -n ib-gateway port-forward svc/ib-gateway-paper 4002:4002
+#   kubectl -n ib-gateway port-forward svc/ib-gateway-live  4001:4001
+#
+# WARNING: ib-gateway-live runs a REAL-MONEY trading session. Compose
+# gates this behind a `live` profile; k8s has no equivalent built-in,
+# so live is just a separate StatefulSet with its own labels. If you
+# want a paper-only smoke run, see the labelled apply above.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ib-gateway
+  labels:
+    mode: shared
+---
+# ─── paper ─────────────────────────────────────────────────────────────
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ib-gateway-paper
+  namespace: ib-gateway
+  labels:
+    app: ib-gateway
+    mode: paper
+type: Opaque
+stringData:
+  IB_ACCOUNT: REPLACE_ME
+  IB_PASSWORD: REPLACE_ME
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ib-gateway-paper
+  namespace: ib-gateway
+  labels:
+    app: ib-gateway
+    mode: paper
+spec:
+  type: ClusterIP
+  selector:
+    app: ib-gateway
+    mode: paper
+  ports:
+    - name: api
+      port: 4002
+      targetPort: api
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ib-gateway-paper
+  namespace: ib-gateway
+  labels:
+    app: ib-gateway
+    mode: paper
+spec:
+  serviceName: ib-gateway-paper
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ib-gateway
+      mode: paper
+  template:
+    metadata:
+      labels:
+        app: ib-gateway
+        mode: paper
+    spec:
+      terminationGracePeriodSeconds: 120
+      # Docker auto-seeds named volumes from the image on first mount; k8s
+      # PVCs always start empty, which would hide the image's pre-installed
+      # /root/Jts/ibgateway/<version>/ binary. Seed once with cp -n (no-clobber)
+      # so this matches docker semantics: fresh PVC gets a full copy, an
+      # existing PVC keeps its jts.ini / fingerprint / autorestart file
+      # untouched. Same caveat as docker — wipe the PVC after a version bump
+      # in versions.env, otherwise the old binary stays. See CLAUDE.md.
+      initContainers:
+        - name: seed-jts
+          image: manhinhang/ib-gateway-docker:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              if [ -z "$(ls -A /pvc 2>/dev/null)" ]; then
+                echo "Empty /root/Jts PVC — seeding from image."
+              else
+                echo "/root/Jts already populated; cp -n only fills gaps."
+              fi
+              # cp -rn (not -a): local-path PVCs reject mtime preservation
+              # on the root dir, which trips set -e. Glob skips dotfiles
+              # but /root/Jts ships only ibgateway/; the ls below fails
+              # loudly if the glob ever matches nothing.
+              cp -rn /root/Jts/* /pvc/
+              ls /pvc/ibgateway
+          volumeMounts:
+            - name: jts
+              mountPath: /pvc
+      containers:
+        - name: ib-gateway
+          image: manhinhang/ib-gateway-docker:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: api
+              containerPort: 4002
+          env:
+            - name: TRADING_MODE
+              value: "paper"
+            - name: IBGW_PORT
+              value: "4002"
+            - name: DISPLAY
+              value: ":99"
+            - name: IB_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: ib-gateway-paper
+                  key: IB_ACCOUNT
+            - name: IB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ib-gateway-paper
+                  key: IB_PASSWORD
+          livenessProbe:
+            exec:
+              command: ["/healthcheck/bin/healthcheck"]
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["/healthcheck/bin/healthcheck"]
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 30
+            failureThreshold: 3
+          volumeMounts:
+            - name: jts
+              mountPath: /root/Jts
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "1Gi"
+            limits:
+              cpu: "1"
+              memory: "1536Mi"
+  volumeClaimTemplates:
+    - metadata:
+        name: jts
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi
+---
+# ─── live (real-money) ─────────────────────────────────────────────────
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ib-gateway-live
+  namespace: ib-gateway
+  labels:
+    app: ib-gateway
+    mode: live
+type: Opaque
+stringData:
+  IB_ACCOUNT: REPLACE_ME
+  IB_PASSWORD: REPLACE_ME
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ib-gateway-live
+  namespace: ib-gateway
+  labels:
+    app: ib-gateway
+    mode: live
+spec:
+  type: ClusterIP
+  selector:
+    app: ib-gateway
+    mode: live
+  ports:
+    - name: api
+      port: 4001
+      targetPort: api
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ib-gateway-live
+  namespace: ib-gateway
+  labels:
+    app: ib-gateway
+    mode: live
+spec:
+  serviceName: ib-gateway-live
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ib-gateway
+      mode: live
+  template:
+    metadata:
+      labels:
+        app: ib-gateway
+        mode: live
+    spec:
+      terminationGracePeriodSeconds: 120
+      # Docker auto-seeds named volumes from the image on first mount; k8s
+      # PVCs always start empty, which would hide the image's pre-installed
+      # /root/Jts/ibgateway/<version>/ binary. Seed once with cp -n (no-clobber)
+      # so this matches docker semantics: fresh PVC gets a full copy, an
+      # existing PVC keeps its jts.ini / fingerprint / autorestart file
+      # untouched. Same caveat as docker — wipe the PVC after a version bump
+      # in versions.env, otherwise the old binary stays. See CLAUDE.md.
+      initContainers:
+        - name: seed-jts
+          image: manhinhang/ib-gateway-docker:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              if [ -z "$(ls -A /pvc 2>/dev/null)" ]; then
+                echo "Empty /root/Jts PVC — seeding from image."
+              else
+                echo "/root/Jts already populated; cp -n only fills gaps."
+              fi
+              # cp -rn (not -a): local-path PVCs reject mtime preservation
+              # on the root dir, which trips set -e. Glob skips dotfiles
+              # but /root/Jts ships only ibgateway/; the ls below fails
+              # loudly if the glob ever matches nothing.
+              cp -rn /root/Jts/* /pvc/
+              ls /pvc/ibgateway
+          volumeMounts:
+            - name: jts
+              mountPath: /pvc
+      containers:
+        - name: ib-gateway
+          image: manhinhang/ib-gateway-docker:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: api
+              containerPort: 4001
+          env:
+            - name: TRADING_MODE
+              value: "live"
+            - name: IBGW_PORT
+              value: "4001"
+            - name: DISPLAY
+              value: ":99"
+            - name: IB_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: ib-gateway-live
+                  key: IB_ACCOUNT
+            - name: IB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ib-gateway-live
+                  key: IB_PASSWORD
+          livenessProbe:
+            exec:
+              command: ["/healthcheck/bin/healthcheck"]
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["/healthcheck/bin/healthcheck"]
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 30
+            failureThreshold: 3
+          volumeMounts:
+            - name: jts
+              mountPath: /root/Jts
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "1Gi"
+            limits:
+              cpu: "1"
+              memory: "1536Mi"
+  volumeClaimTemplates:
+    - metadata:
+        name: jts
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi

--- a/examples/k8s/single.yaml
+++ b/examples/k8s/single.yaml
@@ -1,0 +1,180 @@
+# Single IB Gateway on Kubernetes.
+#
+# Mirrors docker-compose.yaml (one gateway, /root/Jts persisted) for k8s.
+# Apply with:
+#
+#   kubectl apply -f examples/k8s/single.yaml
+#
+# Then put real credentials into the Secret. The pod will not pass the
+# healthcheck without them — bad creds make IBC loop on the login dialog.
+# Two ways to set creds:
+#
+#   # Edit in place (k8s decodes stringData -> data):
+#   kubectl -n ib-gateway edit secret ib-gateway
+#
+#   # Or replace from env vars / .env:
+#   kubectl -n ib-gateway create secret generic ib-gateway \
+#     --from-literal=IB_ACCOUNT="$IB_ACCOUNT" \
+#     --from-literal=IB_PASSWORD="$IB_PASSWORD" \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#
+# After that the StatefulSet should re-roll on its own; if not:
+#
+#   kubectl -n ib-gateway rollout restart statefulset/ib-gateway
+#
+# Connect from your workstation (no LoadBalancer needed):
+#
+#   kubectl -n ib-gateway port-forward svc/ib-gateway 4002:4002
+#
+# Why StatefulSet (not Deployment): /root/Jts holds the IBKR device
+# fingerprint that lets a restart skip 2FA. Each replica must keep its
+# own PVC for life. StatefulSet's volumeClaimTemplates is the natural
+# fit. See CLAUDE.md → Session Persistence.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ib-gateway
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ib-gateway
+  namespace: ib-gateway
+type: Opaque
+stringData:
+  IB_ACCOUNT: REPLACE_ME
+  IB_PASSWORD: REPLACE_ME
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ib-gateway
+  namespace: ib-gateway
+  labels:
+    app: ib-gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: ib-gateway
+  ports:
+    - name: api
+      port: 4002
+      targetPort: api
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ib-gateway
+  namespace: ib-gateway
+  labels:
+    app: ib-gateway
+spec:
+  serviceName: ib-gateway
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ib-gateway
+  template:
+    metadata:
+      labels:
+        app: ib-gateway
+    spec:
+      # IBC's RESTART codepath takes ~60-90s to write the autorestart file
+      # and bounce the JVM. A normal SIGTERM kills the JVM directly without
+      # going through that codepath, so longer grace here only matters for
+      # the rare case where the pod is mid-soft-restart when it's evicted.
+      terminationGracePeriodSeconds: 120
+      # Docker auto-seeds named volumes from the image on first mount; k8s
+      # PVCs always start empty, which would hide the image's pre-installed
+      # /root/Jts/ibgateway/<version>/ binary. Seed once with cp -n (no-clobber)
+      # so this matches docker semantics: fresh PVC gets a full copy, an
+      # existing PVC keeps its jts.ini / fingerprint / autorestart file
+      # untouched. Same caveat as docker — wipe the PVC after a version bump
+      # in versions.env, otherwise the old binary stays. See CLAUDE.md.
+      initContainers:
+        - name: seed-jts
+          image: manhinhang/ib-gateway-docker:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              if [ -z "$(ls -A /pvc 2>/dev/null)" ]; then
+                echo "Empty /root/Jts PVC — seeding from image."
+              else
+                echo "/root/Jts already populated; cp -n only fills gaps."
+              fi
+              # cp -rn (not -a): local-path PVCs reject mtime preservation
+              # on the root dir, which trips set -e. Glob skips dotfiles
+              # but /root/Jts ships only ibgateway/; the ls below fails
+              # loudly if the glob ever matches nothing.
+              cp -rn /root/Jts/* /pvc/
+              ls /pvc/ibgateway
+          volumeMounts:
+            - name: jts
+              mountPath: /pvc
+      containers:
+        - name: ib-gateway
+          image: manhinhang/ib-gateway-docker:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: api
+              containerPort: 4002
+          env:
+            - name: TRADING_MODE
+              value: "paper"
+            # External port clients connect to. socat in start.sh forwards
+            # IBGW_PORT -> IBGW_INTERNAL_PORT inside the pod.
+            - name: IBGW_PORT
+              value: "4002"
+            # Pod has its own X11 abstract-socket namespace, so :99 vs :0
+            # doesn't matter for k8s. Kept at :99 to match compose.
+            - name: DISPLAY
+              value: ":99"
+            - name: IB_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  name: ib-gateway
+                  key: IB_ACCOUNT
+            - name: IB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: ib-gateway
+                  key: IB_PASSWORD
+          # Same probe binary as the compose healthcheck. Liveness lets
+          # k8s restart a wedged JVM; readiness gates the Service from
+          # routing traffic until the gateway is logged in.
+          livenessProbe:
+            exec:
+              command: ["/healthcheck/bin/healthcheck"]
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 30
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command: ["/healthcheck/bin/healthcheck"]
+            initialDelaySeconds: 60
+            periodSeconds: 60
+            timeoutSeconds: 30
+            failureThreshold: 3
+          volumeMounts:
+            - name: jts
+              mountPath: /root/Jts
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "1Gi"
+            limits:
+              cpu: "1"
+              memory: "1536Mi"
+  volumeClaimTemplates:
+    - metadata:
+        name: jts
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests:
+            storage: 1Gi

--- a/scripts/k8s/k3d-down.sh
+++ b/scripts/k8s/k3d-down.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Delete the local k3d cluster created by k3d-up.sh.
+#
+# This wipes everything in the cluster — PVCs, Secrets, the lot.
+# The local `manhinhang/ib-gateway-docker:dev` image stays in the host
+# Docker daemon (k3d image import only copies it into the cluster).
+
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-ib-gateway}"
+
+if k3d cluster list "$CLUSTER_NAME" >/dev/null 2>&1; then
+    echo "==> Deleting k3d cluster '$CLUSTER_NAME'..."
+    k3d cluster delete "$CLUSTER_NAME"
+else
+    echo "==> No k3d cluster '$CLUSTER_NAME' to delete."
+fi

--- a/scripts/k8s/k3d-up.sh
+++ b/scripts/k8s/k3d-up.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# Stand up a local k3d cluster, build the IB Gateway image, ship it into
+# the cluster, and apply the example manifests.
+#
+# By default this is a SMOKE test: PVCs bind, the pod schedules, the
+# image pulls, the container starts, IBC begins its login attempt. The
+# pod will NOT pass the healthcheck without real IBKR credentials —
+# that's expected and is the right stopping point for "is the k8s wiring
+# correct?". To go further (full session login + soft-restart proof),
+# put real paper creds into the Secret and run
+# scripts/k8s/verify-session-persistence-k8s.sh.
+#
+# Override via env:
+#   CLUSTER_NAME   k3d cluster name              (default: ib-gateway)
+#   IMAGE          local image tag               (default: manhinhang/ib-gateway-docker:dev)
+#   MANIFEST       which example to apply        (default: examples/k8s/single.yaml)
+#   NAMESPACE      target namespace              (default: ib-gateway)
+#   IB_ACCOUNT,    IBKR creds; if both set, the
+#   IB_PASSWORD    Secret is replaced with them. Otherwise REPLACE_ME stays.
+#   SKIP_BUILD=1   reuse an existing local image (skips docker build)
+#   USE_HOST_NETWORK=1
+#                  pass --network host to k3d cluster create. This makes the
+#                  k3s server container share the host's network namespace
+#                  (including DNS), which fixes Docker Hub TLS handshake
+#                  timeouts on hosts where the docker bridge has flaky
+#                  outbound DNS. Cannot be used if the host already has
+#                  containers attached to the host network without IPs
+#                  (k3d's prep step rejects them) — fall back to the
+#                  manual ctr-import workaround in examples/k8s/README.md
+#                  in that case.
+
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-ib-gateway}"
+IMAGE="${IMAGE:-manhinhang/ib-gateway-docker:dev}"
+MANIFEST="${MANIFEST:-examples/k8s/single.yaml}"
+NAMESPACE="${NAMESPACE:-ib-gateway}"
+SKIP_BUILD="${SKIP_BUILD:-0}"
+
+# Resolve repo root so the script works from any directory.
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "ERROR: '$1' not found on PATH." >&2
+        exit 2
+    }
+}
+
+require docker
+require kubectl
+require k3d
+
+if ! k3d cluster list "$CLUSTER_NAME" >/dev/null 2>&1; then
+    echo "==> Creating k3d cluster '$CLUSTER_NAME' (no LB; we use port-forward)..."
+    # --no-lb: skip the traefik LB; we use kubectl port-forward to reach
+    #          the gateway from the host, so the LB is dead weight.
+    # --servers 1 --agents 0: smallest viable cluster.
+    create_args=(--no-lb --servers 1 --agents 0)
+    if [ "${USE_HOST_NETWORK:-0}" = "1" ]; then
+        echo "    USE_HOST_NETWORK=1 — joining the docker host network."
+        create_args+=(--network host)
+    fi
+    k3d cluster create "$CLUSTER_NAME" "${create_args[@]}"
+else
+    echo "==> Reusing existing k3d cluster '$CLUSTER_NAME'."
+fi
+
+if [ "$SKIP_BUILD" != "1" ]; then
+    echo "==> Building local image $IMAGE..."
+    # network=host because the host's docker bridge has flaky DNS to
+    # deb.debian.org during apt-get inside the build (same workaround
+    # used by docker-compose.yaml's `network: host` build flag).
+    docker build --network host -t "$IMAGE" .
+else
+    echo "==> SKIP_BUILD=1 — assuming $IMAGE already exists locally."
+    docker image inspect "$IMAGE" >/dev/null 2>&1 || {
+        echo "ERROR: $IMAGE not present locally and SKIP_BUILD=1." >&2
+        exit 2
+    }
+fi
+
+echo "==> Importing $IMAGE into k3d cluster '$CLUSTER_NAME'..."
+k3d image import "$IMAGE" -c "$CLUSTER_NAME"
+
+echo "==> Applying $MANIFEST..."
+# Patch the image tag in the manifest on the fly so the local :dev image
+# is what the StatefulSet pulls (otherwise it would request :latest from
+# Docker Hub and ignore the imported one).
+tmp_manifest="$(mktemp)"
+trap 'rm -f "$tmp_manifest"' EXIT
+# The default image in the manifest is `manhinhang/ib-gateway-docker:latest`.
+# Swap to whatever IMAGE points at.
+sed -E "s|image: manhinhang/ib-gateway-docker:latest|image: ${IMAGE}|g" \
+    "$MANIFEST" >"$tmp_manifest"
+kubectl apply -f "$tmp_manifest"
+
+if [ -n "${IB_ACCOUNT:-}" ] && [ -n "${IB_PASSWORD:-}" ]; then
+    echo "==> Replacing Secret with IB_ACCOUNT/IB_PASSWORD from environment..."
+    if [ "$MANIFEST" = "examples/k8s/multi.yaml" ]; then
+        # Multi-file lookup: prefer paper creds for the paper Secret if
+        # the *_PAPER env vars are set; otherwise fall through to the
+        # generic IB_ACCOUNT/IB_PASSWORD.
+        paper_account="${IB_PAPER_ACCOUNT:-$IB_ACCOUNT}"
+        paper_password="${IB_PAPER_PASSWORD:-$IB_PASSWORD}"
+        kubectl -n "$NAMESPACE" create secret generic ib-gateway-paper \
+            --from-literal=IB_ACCOUNT="$paper_account" \
+            --from-literal=IB_PASSWORD="$paper_password" \
+            --dry-run=client -o yaml | kubectl apply -f -
+        if [ -n "${IB_LIVE_ACCOUNT:-}" ] && [ -n "${IB_LIVE_PASSWORD:-}" ]; then
+            kubectl -n "$NAMESPACE" create secret generic ib-gateway-live \
+                --from-literal=IB_ACCOUNT="$IB_LIVE_ACCOUNT" \
+                --from-literal=IB_PASSWORD="$IB_LIVE_PASSWORD" \
+                --dry-run=client -o yaml | kubectl apply -f -
+        else
+            echo "    NOTE: ib-gateway-live Secret left as REPLACE_ME (no IB_LIVE_* creds)."
+        fi
+    else
+        kubectl -n "$NAMESPACE" create secret generic ib-gateway \
+            --from-literal=IB_ACCOUNT="$IB_ACCOUNT" \
+            --from-literal=IB_PASSWORD="$IB_PASSWORD" \
+            --dry-run=client -o yaml | kubectl apply -f -
+    fi
+    # Force pods to pick up the new Secret values.
+    kubectl -n "$NAMESPACE" rollout restart statefulset --selector=app=ib-gateway
+else
+    echo "==> No IB_ACCOUNT/IB_PASSWORD in env — Secret stays at REPLACE_ME."
+    echo "    The pod will start but won't pass the healthcheck without real creds."
+fi
+
+echo "==> Waiting up to 180s for pod(s) to reach Running..."
+# Running != Ready. We deliberately don't wait for Ready here because
+# Ready depends on the healthcheck, which requires real credentials.
+# Reaching Running means the image pulled, the container started, and
+# start.sh executed at least up to the IBC login attempt.
+deadline=$(( SECONDS + 180 ))
+while [ "$SECONDS" -lt "$deadline" ]; do
+    pods="$(kubectl -n "$NAMESPACE" get pods -l app=ib-gateway \
+        -o jsonpath='{range .items[*]}{.status.phase}{"\n"}{end}' 2>/dev/null || echo)"
+    if [ -n "$pods" ] && ! printf '%s\n' "$pods" | grep -vqE '^(Running|Succeeded)$'; then
+        echo "    All gateway pods are Running."
+        break
+    fi
+    sleep 5
+done
+
+echo
+echo "==> Cluster state:"
+kubectl -n "$NAMESPACE" get statefulset,svc,pvc,pod
+echo
+echo "==> Smoke verification (env wiring + image identity)..."
+for pod in $(kubectl -n "$NAMESPACE" get pods -l app=ib-gateway -o name 2>/dev/null); do
+    echo "--- $pod ---"
+    kubectl -n "$NAMESPACE" exec "$pod" -- env 2>/dev/null \
+        | grep -E '^(IBGW_|TRADING_MODE|DISPLAY|IB_ACCOUNT)=' \
+        | sed -E 's/^(IB_ACCOUNT)=.*$/\1=<set>/'
+done
+
+echo
+echo "Done. Useful next commands:"
+echo "  kubectl -n $NAMESPACE logs -f -l app=ib-gateway"
+echo "  kubectl -n $NAMESPACE port-forward svc/ib-gateway 4002:4002"
+echo "  scripts/k8s/restart-ib-gateway-k8s.sh         # ad-hoc soft restart"
+echo "  scripts/k8s/verify-session-persistence-k8s.sh # full proof (real creds)"
+echo "  scripts/k8s/k3d-down.sh                        # tear down the cluster"

--- a/scripts/k8s/restart-ib-gateway-k8s.sh
+++ b/scripts/k8s/restart-ib-gateway-k8s.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Trigger IB Gateway's soft restart inside a k8s pod via IBC's command
+# server on loopback. K8s analogue of scripts/restart-ib-gateway.sh.
+#
+# Why: a plain `kubectl delete pod` (or rollout restart) kills the JVM
+# directly, which prevents IB Gateway from writing the autorestart file
+# that lets the next launch skip 2FA. IBC's RESTART command runs the
+# same internal codepath as the scheduled AutoRestartTime — the
+# autorestart file gets written before the JVM bounces, so the new
+# process reuses the session.
+#
+# The IBC command server is bound to 127.0.0.1 inside the pod (set via
+# IBC_BIND_ADDRESS in start.sh). We reach it via `kubectl exec`, which
+# preserves the loopback-only trust boundary — no Service object needed.
+#
+# Override via env:
+#   NAMESPACE   k8s namespace                     (default: ib-gateway)
+#   POD         pod name (overrides label-based discovery)
+#   LABEL       label selector to find the pod    (default: app=ib-gateway)
+#   PORT        IBC command server port           (default: 7462)
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-ib-gateway}"
+LABEL="${LABEL:-app=ib-gateway}"
+PORT="${PORT:-${IBC_COMMAND_SERVER_PORT:-7462}}"
+
+if [ -z "${POD:-}" ]; then
+    POD="$(kubectl -n "$NAMESPACE" get pod -l "$LABEL" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    if [ -z "$POD" ]; then
+        echo "ERROR: no pod found in namespace '$NAMESPACE' with label '$LABEL'." >&2
+        echo "  Set POD=<name> explicitly, or check 'kubectl -n $NAMESPACE get pods'." >&2
+        exit 1
+    fi
+fi
+
+echo "==> Sending IBC RESTART to pod $NAMESPACE/$POD on 127.0.0.1:$PORT..."
+
+# We open /dev/tcp inside the pod (bash builtin) rather than using
+# `kubectl port-forward` + a host-side connect: it avoids a separate
+# port-forward process, and there's no advantage to going through the
+# host since the command server is loopback-only by design.
+kubectl exec -n "$NAMESPACE" "$POD" -- bash -c '
+    set -e
+    PORT="$1"
+    if ! exec 3<>"/dev/tcp/127.0.0.1/$PORT" 2>/dev/null; then
+        echo "ERROR: cannot connect to IBC command server at 127.0.0.1:$PORT inside pod" >&2
+        echo "  - is IBC up?   (kubectl logs ...)" >&2
+        echo "  - is CommandServerPort set in ibc/config.ini?" >&2
+        exit 1
+    fi
+    printf "RESTART\n" >&3
+    # 2-second per-line read timeout matches the host-side script.
+    while IFS= read -t 2 -r line <&3; do
+        printf "%s\n" "$line"
+    done
+    exec 3<&-
+' _ "$PORT"
+
+echo "==> Sent. IB Gateway will run its soft-restart cycle (~60-90s)."
+echo "    Watch:   kubectl -n $NAMESPACE logs -f $POD"
+echo "    Verify:  scripts/k8s/verify-session-persistence-k8s.sh"

--- a/scripts/k8s/verify-session-persistence-k8s.sh
+++ b/scripts/k8s/verify-session-persistence-k8s.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Verify that an in-flight IB Gateway pod survives an IBC soft restart
+# without re-prompting for 2FA. K8s analogue of
+# scripts/verify-session-persistence.sh.
+#
+# Preconditions:
+#   - Pod is up and Ready (which means: real creds in the Secret, and
+#     2FA was completed on the IBKR mobile app on the very first start).
+#   - IBC command server is enabled in ibc/config.ini (default).
+#
+# Pass criteria (same as the docker script):
+#   - IBC accepts the RESTART command
+#   - Pod returns to Ready within HEALTH_TIMEOUT seconds
+#   - Post-restart logs contain no second-factor / 2FA prompts
+#   - Autorestart file is present in /root/Jts after the restart
+#
+# Exit codes: 0 = pass, 1 = fail, 2 = misuse / preconditions missing.
+#
+# Override via env:
+#   NAMESPACE         k8s namespace               (default: ib-gateway)
+#   LABEL             label selector for the pod (default: app=ib-gateway)
+#   POD               explicit pod name (skips LABEL discovery)
+#   HEALTH_TIMEOUT    seconds to wait for Ready  (default: 240)
+#   RESTART_TIMEOUT   seconds to wait for the restart cycle (default: 240)
+#   RESTART_HELPER    path to restart helper     (default: ../restart-ib-gateway-k8s.sh)
+#   PORT              IBC command server port    (default: 7462)
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-ib-gateway}"
+LABEL="${LABEL:-app=ib-gateway}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-240}"
+RESTART_TIMEOUT="${RESTART_TIMEOUT:-240}"
+RESTART_HELPER="${RESTART_HELPER:-$(dirname "$0")/restart-ib-gateway-k8s.sh}"
+PORT="${PORT:-${IBC_COMMAND_SERVER_PORT:-7462}}"
+
+current_pod() {
+    if [ -n "${POD:-}" ]; then
+        printf '%s\n' "$POD"
+        return
+    fi
+    kubectl -n "$NAMESPACE" get pod -l "$LABEL" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+# Returns "true" / "false" / "" depending on Ready condition status.
+ready_status() {
+    local pod="$1"
+    kubectl -n "$NAMESPACE" get pod "$pod" \
+        -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null
+}
+
+wait_ready() {
+    local pod="$1" deadline=$(( SECONDS + HEALTH_TIMEOUT ))
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        case "$(ready_status "$pod")" in
+            True) return 0 ;;
+        esac
+        sleep 5
+    done
+    echo "FAIL: pod '$pod' did not become Ready within ${HEALTH_TIMEOUT}s" >&2
+    return 1
+}
+
+pod="$(current_pod)"
+if [ -z "$pod" ]; then
+    echo "FAIL: no pod found in '$NAMESPACE' for selector '$LABEL'" >&2
+    echo "  Bring it up first, complete 2FA, and re-run." >&2
+    exit 2
+fi
+
+initial="$(ready_status "$pod")"
+if [ "$initial" != "True" ]; then
+    echo "FAIL: pod '$pod' is not Ready before restart (Ready=$initial)" >&2
+    echo "  Did you complete 2FA on the IBKR mobile app on the first start?" >&2
+    exit 2
+fi
+
+if [ ! -x "$RESTART_HELPER" ]; then
+    echo "FAIL: restart helper not found or not executable: $RESTART_HELPER" >&2
+    exit 2
+fi
+
+echo "Pre-restart: pod '$pod' is Ready. Sending IBC RESTART..."
+# kubectl logs --since-time wants RFC3339; date -u with 'Z' suffix matches.
+restart_started_at_iso="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+NAMESPACE="$NAMESPACE" POD="$pod" PORT="$PORT" "$RESTART_HELPER"
+
+# IBC's RESTART is async — it sets the auto-restart time to "now + ~1m"
+# and lets IB Gateway's normal soft-restart logic fire. Watch the pod's
+# logs for one of:
+#   - "autorestart file found"      → success marker
+#   - "autorestart file not found"  → file wasn't written, FAIL
+#   - "Second Factor Authentication initiated" → 2FA, FAIL
+echo "Waiting up to ${RESTART_TIMEOUT}s for the restart cycle to fire..."
+deadline=$(( SECONDS + RESTART_TIMEOUT ))
+restart_outcome=""
+while [ "$SECONDS" -lt "$deadline" ]; do
+    # IB Gateway's soft restart bounces the JVM in-place inside the
+    # same container, so the pod name does NOT change. If for some
+    # reason the container *did* die (uncaught error etc.), the pod
+    # name still stays the same under StatefulSet semantics — the
+    # restart count goes up, that's all.
+    new_logs="$(kubectl -n "$NAMESPACE" logs "$pod" \
+        --since-time="$restart_started_at_iso" 2>&1 || true)"
+    if printf '%s' "$new_logs" | grep -qiE 'autorestart file found'; then
+        restart_outcome="found"; break
+    fi
+    if printf '%s' "$new_logs" | grep -qiE 'autorestart file not found'; then
+        restart_outcome="missing"; break
+    fi
+    if printf '%s' "$new_logs" | grep -qiE 'Second Factor Authentication initiated'; then
+        restart_outcome="2fa"; break
+    fi
+    sleep 5
+done
+
+case "$restart_outcome" in
+    "")
+        echo "FAIL: restart cycle did not complete within ${RESTART_TIMEOUT}s" >&2
+        echo "      no 'autorestart file (found|not found)' since ${restart_started_at_iso}" >&2
+        echo "--- last 60 log lines ---" >&2
+        kubectl -n "$NAMESPACE" logs "$pod" --tail=60 >&2 || true
+        exit 1
+        ;;
+    "missing")
+        echo "FAIL: launcher reported 'autorestart file not found' on the" >&2
+        echo "      post-restart launch. The IBC RESTART codepath did not" >&2
+        echo "      write the autorestart file as expected." >&2
+        exit 1
+        ;;
+    "2fa")
+        echo "FAIL: 2FA was triggered after the IBC RESTART (autorestart" >&2
+        echo "      file likely missing or expired)." >&2
+        exit 1
+        ;;
+    "found")
+        echo "  - launcher confirmed: autorestart file found"
+        ;;
+esac
+
+echo "Post-restart: waiting for Ready (timeout ${HEALTH_TIMEOUT}s)..."
+if ! wait_ready "$pod"; then
+    echo "--- last 100 log lines ---" >&2
+    kubectl -n "$NAMESPACE" logs "$pod" --tail=100 >&2 || true
+    exit 1
+fi
+
+# Final defensive scan: even if the launcher said "found", confirm no
+# 2FA dialog appeared during the post-restart login.
+post_logs="$(kubectl -n "$NAMESPACE" logs "$pod" \
+    --since-time="$restart_started_at_iso" 2>&1 || true)"
+if printf '%s' "$post_logs" | grep -qiE 'Second Factor Authentication initiated|sms code|please respond'; then
+    echo "FAIL: 2FA-related markers found in post-restart logs despite autorestart file:" >&2
+    printf '%s' "$post_logs" | grep -iE 'Second Factor Authentication initiated|sms code|please respond' >&2
+    exit 1
+fi
+
+# Positive proof on disk: the autorestart file lives in a per-instance
+# dir under /root/Jts (e.g. /root/Jts/ghdiikhpohjdpkekgoiaeondhmnnfepnbmldcgal/autorestart).
+echo "Confirming autorestart file on disk in /root/Jts..."
+if kubectl -n "$NAMESPACE" exec "$pod" -- sh -c \
+        'find /root/Jts -maxdepth 3 -name autorestart -type f -print 2>/dev/null | head -3' \
+        | grep -q .; then
+    echo "  - autorestart file present on disk"
+else
+    echo "  - autorestart file not visible via find (launcher confirmed it though)"
+fi
+
+echo
+echo "PASS: pod '$pod' restarted via IBC command server with no 2FA prompt."
+echo "      Autorestart file is in place; subsequent restarts will also"
+echo "      skip 2FA until it expires (Sunday 1AM ET hard reset)."


### PR DESCRIPTION
## Summary

Adds plain-YAML Kubernetes manifests that mirror the project's `docker-compose.yaml` (single gateway) and `docker-compose.multi.yaml` (paper + live) setups, plus a k3d-based local verification path and a CI step that exercises the manifests end-to-end on every PR.

## Changes

**Manifests** (`examples/k8s/`):
- `single.yaml` — one StatefulSet/Service/Secret in namespace `ib-gateway`, mirrors single-gateway compose.
- `multi.yaml` — paper + live StatefulSets/Services/Secrets, mirrors multi-gateway compose. The compose multi setup's per-service `IBGW_INTERNAL_PORT` and `IBC_COMMAND_SERVER_PORT` overrides do **not** transfer — those exist only because `network_mode: host` makes paper and live share the host's loopback. Each k8s pod has its own network namespace, so both pods keep upstream defaults internally and only `IBGW_PORT` differs.
- Both manifests carry a `seed-jts` initContainer that `cp -rn`s `/root/Jts/*` from the image onto the empty PVC on first start. k8s PVCs (unlike docker named volumes) start empty and would otherwise hide the image's `ibgateway/<version>/` binary.

**Helper scripts** (`scripts/k8s/`):
- `k3d-up.sh` — creates k3d cluster, builds + imports the local image, applies a manifest, runs a smoke check. `USE_HOST_NETWORK=1` opts into host networking when the docker bridge has flaky DNS; falls back to a documented manual ctr-import path.
- `k3d-down.sh` — tears down.
- `restart-ib-gateway-k8s.sh` — k8s analogue of `scripts/restart-ib-gateway.sh`. `kubectl exec`s into the pod and sends `RESTART\n` to IBC's command server on `127.0.0.1:7462`, preserving the loopback-only trust boundary.
- `verify-session-persistence-k8s.sh` — k8s analogue of `scripts/verify-session-persistence.sh`. Same pass criteria (autorestart file written, no 2FA prompts post-restart).

**CI** (`.github/workflows/build-test.yml`):
- New k8s steps after the existing docker tests: install k3d (pinned to v5.7.5 install.sh by commit SHA), create cluster, import image, apply manifest with `secrets.IB_ACCOUNT`/`secrets.IB_PASSWORD`, then `kubectl rollout status statefulset/ib-gateway` (race-tolerant across rollout-restart pod recreation).
- Diagnostics dump on failure (describe pod + initContainer logs + main container logs).
- Cluster torn down with `if: always()`.
- Bumped job timeout 20 → 25 min to absorb the k8s steps.

**Docs**:
- `examples/k8s/README.md` — quickstart, smoke vs full verification, soft-restart flow, "if k3d can't reach Docker Hub" troubleshooting.
- `CLAUDE.md` — short pointer to `examples/k8s/` noting that compose's per-pod port juggling does not transfer to k8s.

## Files Changed

| File | Type |
|---|---|
| `.github/workflows/build-test.yml` | Modified |
| `CLAUDE.md` | Modified |
| `examples/k8s/README.md` | Added |
| `examples/k8s/single.yaml` | Added |
| `examples/k8s/multi.yaml` | Added |
| `scripts/k8s/k3d-up.sh` | Added |
| `scripts/k8s/k3d-down.sh` | Added |
| `scripts/k8s/restart-ib-gateway-k8s.sh` | Added |
| `scripts/k8s/verify-session-persistence-k8s.sh` | Added |

## Testing

- **Local k3d smoke run** (no real IBKR creds): PVC `Bound`, pod `Running`, env wired, IBC reaches login attempt — confirmed end-to-end on a local k3d cluster with the imported image. Resource use at idle: 3m CPU, 341Mi memory (well within the configured 1 CPU / 1.5Gi limits).
- **Manifest dry-run** (`kubectl create --dry-run=client -f ... -o name`): both `single.yaml` and `multi.yaml` resolve clean.
- **Bash syntax** (`bash -n`): all four helper scripts pass.
- **Workflow YAML** (`yaml.safe_load`): valid.
- **Full session-persistence verification with real paper credentials**: not run locally; covered by the new CI step on this PR.

## Related Issues

None.