### PR TITLE
Fix workflow recursion: trigger build-test explicitly on version PRs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,6 +8,7 @@ on:
       - 'README.md'
       - 'LICENSE'
   pull_request:
+  workflow_dispatch:
 
 env:
   # Opt every JavaScript-based action into Node.js 24. Node 20 is deprecated
@@ -18,7 +19,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     timeout-minutes: 25
     env:
       IMAGE_NAME: ib-gateway-docker

--- a/.github/workflows/detect-new-ver.yml
+++ b/.github/workflows/detect-new-ver.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
+      actions: write
     env:
       IMAGE_NAME: ib-gateway-docker
       IBC_VERSION_JSON_URL: "https://api.github.com/repos/IbcAlpha/IBC/releases"
@@ -96,3 +97,10 @@ jobs:
         git push --set-upstream origin "$branch"
 
         gh pr create --base master --fill
+
+        # PRs opened with GITHUB_TOKEN do NOT trigger on:pull_request workflows
+        # (GitHub anti-recursion). workflow_dispatch is exempt from that
+        # suppression, so kick build-test explicitly against the new branch;
+        # its check runs land on the PR's head commit and satisfy branch
+        # protection.
+        gh workflow run build-test.yml --ref "$branch"


### PR DESCRIPTION
## Summary

GitHub Actions suppresses `on:pull_request` workflows when a PR is opened by `GITHUB_TOKEN` to prevent infinite recursion. This breaks the automated version detection workflow: it creates a PR with a new IB Gateway/IBC version, but the `build-test` workflow never runs, so branch protection checks don't pass and the PR can't be merged.

This change explicitly triggers the `build-test` workflow via `workflow_dispatch` against the new branch, ensuring CI checks run and satisfy branch protection requirements.

## Key Changes

- **detect-new-ver.yml**: Added `actions: write` permission and explicit `gh workflow run build-test.yml --ref "$branch"` call after creating the version PR
- **build-test.yml**: 
  - Added `workflow_dispatch:` trigger to allow explicit invocation
  - Updated the draft-check condition to handle both `pull_request` and `workflow_dispatch` events: `if: github.event_name != 'pull_request' || github.event.pull_request.draft == false`

## Implementation Details

The `workflow_dispatch` trigger is exempt from GitHub's anti-recursion suppression, so it can be safely invoked from within another workflow. The draft-check condition ensures that:
- For `pull_request` events: the job skips if the PR is a draft (existing behavior)
- For `workflow_dispatch` events: the job always runs (no draft concept for manual triggers)
- For other event types: the job always runs

This allows the automated version detection workflow to reliably trigger CI checks on its generated PRs without requiring manual intervention.

https://claude.ai/code/session_01FKtQ8eexfECtLqvgR5oqGc