### PR TITLE
Auto-merge version update PRs once required checks pass

### DIFF
--- a/.github/workflows/detect-new-ver.yml
+++ b/.github/workflows/detect-new-ver.yml
@@ -96,7 +96,7 @@ jobs:
         git commit -m 'Update to latest `${{ steps.check-update.outputs.ib-gateway-latest-ver }}` stable `${{ steps.check-update.outputs.ib-gateway-stable-ver }}`'
         git push --set-upstream origin "$branch"
 
-        gh pr create --base master --fill
+        pr_url=$(gh pr create --base master --fill)
 
         # PRs opened with GITHUB_TOKEN do NOT trigger on:pull_request workflows
         # (GitHub anti-recursion). workflow_dispatch is exempt from that
@@ -104,3 +104,6 @@ jobs:
         # its check runs land on the PR's head commit and satisfy branch
         # protection.
         gh workflow run build-test.yml --ref "$branch"
+
+        # Queue the PR to merge automatically once required checks pass.
+        gh pr merge "$pr_url" --auto --squash


### PR DESCRIPTION
## Summary

Enhance the automated version detection workflow to automatically merge version update PRs once all required status checks pass, eliminating manual merge steps for routine dependency updates.

## Changes

- Capture the PR URL returned by `gh pr create` instead of discarding it
- Queue the PR for automatic merge using `gh pr merge --auto --squash` after triggering the build-test workflow
- This ensures the PR merges automatically once required checks complete, streamlining the version update process

## Implementation Details

The workflow now:
1. Creates the version update PR and captures its URL
2. Triggers the `build-test.yml` workflow against the new branch (whose checks land on the PR's head commit)
3. Queues the PR for automatic squash merge once those required checks pass

This maintains the existing branch protection requirements while removing the need for manual PR review/merge of routine version updates.

https://claude.ai/code/session_012EiPbY35wa28r77xqQeoBM