### PR TITLE
Add test job to deploy workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,6 +9,7 @@ on:
       - 'LICENSE'
   pull_request:
   workflow_dispatch:
+  workflow_call:
 
 env:
   # Opt every JavaScript-based action into Node.js 24. Node 20 is deprecated

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,12 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  test:
+    uses: ./.github/workflows/build-test.yml
+    secrets: inherit
+
   build:
+    needs: test
     strategy:
       matrix:
         channel: [stable, latest]


### PR DESCRIPTION
## Summary
Refactors the CI/CD pipeline to run tests before deployment by introducing a dedicated `test` job in the deploy workflow that calls the existing `build-test.yml` workflow.

## Changes
- **deploy.yml**: Added a new `test` job that uses the `build-test.yml` workflow with `secrets: inherit`, and made the `build` job depend on it via `needs: test`
- **build-test.yml**: Added `workflow_call` trigger to allow the workflow to be called from other workflows (specifically from `deploy.yml`)

## Implementation Details
- The test job runs before the build job, ensuring tests pass before any deployment artifacts are created
- Secrets are inherited from the parent workflow context, allowing the test job to access any necessary credentials
- This follows the standard GitHub Actions pattern of composing workflows for better modularity and reusability

https://claude.ai/code/session_013pgKrhX3T3tpWRp29BgH6Y