### PR TITLE
Adjust detect-new-ver cron schedule to avoid IBKR maintenance

### DIFF
--- a/.github/workflows/detect-new-ver.yml
+++ b/.github/workflows/detect-new-ver.yml
@@ -1,7 +1,9 @@
 name: Detect new version
 on:
   schedule:
-    - cron: '0 0 * * *'
+    # 12:00 UTC clears IBKR's ~01:00-local regional maintenance windows;
+    # day range 0-5 (Sun-Fri) skips Saturday weekly maintenance.
+    - cron: '0 12 * * 0-5'
   workflow_dispatch:
 
 env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -282,7 +282,7 @@ Two health check methods are available:
    - Requires secrets: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`
 
 3. **detect-new-ver.yml** - Automated version updates
-   - Runs daily via cron
+   - Runs Sun-Fri at 12:00 UTC via cron (skips Saturday to avoid IBKR maintenance)
    - Detects new IB Gateway and IBC versions
    - Creates PR with updated Dockerfile and README
    - Uses version detection scripts


### PR DESCRIPTION
## Summary
Updated the `detect-new-ver` workflow schedule to run at 12:00 UTC on weekdays (Sun-Fri) instead of daily at midnight UTC, avoiding Interactive Brokers' regional maintenance windows and Saturday weekly maintenance.

## Changes
- **Cron schedule**: Changed from `0 0 * * *` (daily at 00:00 UTC) to `0 12 * * 0-5` (12:00 UTC, Sun-Fri only)
- **Documentation**: Updated CLAUDE.md to reflect the new schedule and explain the rationale

## Details
The new schedule:
- Runs at **12:00 UTC** to clear IBKR's ~01:00-local regional maintenance windows across different time zones
- Skips **Saturday** (day range 0-5 excludes day 6) to avoid IBKR's weekly maintenance window
- Maintains automated version detection while reducing false failures due to IBKR service unavailability

This aligns with the project's operational practices documented in CLAUDE.md regarding maintenance windows and service reliability.

https://claude.ai/code/session_01VkZKsHTqQv6RMwmzcacFPN