### PR TITLE
Resolve TWS API URL by probing github.io for available versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,33 @@ RUN curl -fsSL "https://download2.interactivebrokers.com/installers/ibgateway/${
  | sed -E 's/^[^(]+\(//; s/\);[[:space:]]*$//' \
  | jq -r '.buildVersion' > /tmp/ibgw-version
 
+# Resolve the matching TWS API zip URL. IB routinely ships a new
+# gateway minor before publishing the matching twsapi_macunix.NN.01.zip
+# on github.io, so probe the exact derived URL and walk back through
+# earlier minors of the same major until one resolves. The result is
+# persisted to /tmp/ibgw-api-url for the healthcheck-tools stage,
+# which uses gradle:8.7.0-jdk17 and doesn't ship curl.
+RUN IB_VER=$(cat /tmp/ibgw-version) \
+ && MAJOR=$(echo "$IB_VER" | cut -d. -f1) \
+ && MINOR=$(echo "$IB_VER" | cut -d. -f2) \
+ && IB_API_URL="" \
+ && for offset in $(seq 0 10); do \
+      candidate=$((MINOR - offset)); \
+      [ "$candidate" -lt 0 ] && break; \
+      URL="https://interactivebrokers.github.io/downloads/twsapi_macunix.${MAJOR}${candidate}.01.zip"; \
+      if curl -fsIL -o /dev/null "$URL"; then \
+        echo "resolved IBAPI URL: $URL"; \
+        IB_API_URL="$URL"; \
+        break; \
+      fi; \
+      echo "  miss: $URL"; \
+    done \
+ && if [ -z "$IB_API_URL" ]; then \
+      echo "ERROR: no twsapi_macunix.${MAJOR}NN.01.zip found within 10 minors of ${IB_VER}" >&2; \
+      exit 1; \
+    fi \
+ && echo "$IB_API_URL" > /tmp/ibgw-api-url
+
 ######## healthcheck tools ########
 # temp container to build using gradle
 FROM gradle:8.7.0-jdk17 AS healthcheck-tools
@@ -55,12 +82,12 @@ ENV APP_HOME=/usr/app/
 WORKDIR $APP_HOME
 COPY healthcheck $APP_HOME
 COPY --from=downloader /tmp/ibgw-version /tmp/ibgw-version
+COPY --from=downloader /tmp/ibgw-api-url /tmp/ibgw-api-url
 
-# Derive IBAPI URL from gateway version (e.g., 10.45.1c → twsapi_macunix.1045.01.zip)
-RUN IB_VER=$(cat /tmp/ibgw-version) && \
-    MAJOR=$(echo $IB_VER | cut -d. -f1) && \
-    MINOR=$(echo $IB_VER | cut -d. -f2) && \
-    IB_API_URL="https://interactivebrokers.github.io/downloads/twsapi_macunix.${MAJOR}${MINOR}.01.zip" && \
+# Use the IBAPI URL resolved in the downloader stage (which probed
+# github.io for the closest available twsapi_macunix.NN.01.zip to the
+# installed gateway version).
+RUN IB_API_URL=$(cat /tmp/ibgw-api-url) && \
     gradle clean build -PibApiUrl=$IB_API_URL
 
 RUN mkdir -p $APP_HOME/build


### PR DESCRIPTION
## Summary

This change improves the robustness of TWS API dependency resolution by probing Interactive Brokers' github.io repository for the closest available `twsapi_macunix.NN.01.zip` version, rather than assuming an exact match exists for the installed IB Gateway version.

## Problem

IB Gateway releases new minor versions more frequently than the matching TWS API zip files are published to github.io. The previous approach derived a URL based on the exact gateway version (e.g., `10.45.1c` → `twsapi_macunix.1045.01.zip`), which would fail if that specific minor version's API zip hadn't been published yet.

## Solution

- **Downloader stage**: Added a new RUN block that resolves the TWS API URL by:
  - Extracting the major and minor version from the installed IB Gateway
  - Probing up to 10 earlier minor versions of the same major release
  - Using `curl -fsIL` to check URL availability without downloading
  - Persisting the resolved URL to `/tmp/ibgw-api-url` for the next build stage
  - Failing with a clear error message if no matching API zip is found

- **Healthcheck tools stage**: Updated to:
  - Copy the pre-resolved URL from the downloader stage
  - Use the resolved URL directly instead of deriving it
  - Simplify the gradle build invocation

## Implementation Details

- The probe loop walks backward through minor versions (e.g., 45, 44, 43, ...) to find the closest available match
- Each candidate URL is tested with `curl -fsIL -o /dev/null` (HEAD request, no download)
- Diagnostic output logs both successful resolution and misses for troubleshooting
- The resolved URL is persisted to a file because the gradle stage uses a different base image (`gradle:8.7.0-jdk17`) that doesn't ship curl
- Graceful failure with exit code 1 if no suitable API zip is found within 10 minor versions

https://claude.ai/code/session_01G7SvTT364YWBcjoyWVCZTh